### PR TITLE
Issue/1 library cannot be installed via composer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "wp-tlc-transients"]
-	path = wp-tlc-transients
-	url = https://github.com/markjaquith/WP-TLC-Transients.git

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,13 @@
 {
     "name": "webdevstudios/wds-tlc-transients",
     "type": "wordpress-plugin",
-    "require": {}
+    "require": {
+        "markjaquith/wp-tlc-transients": "dev-master"
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/markjaquith/wp-tlc-transients.git"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -2,12 +2,16 @@
     "name": "webdevstudios/wds-tlc-transients",
     "type": "wordpress-plugin",
     "require": {
-        "markjaquith/wp-tlc-transients": "dev-master"
+        "markjaquith/wp-tlc-transients": "dev-master",
+        "composer/installers": "^1"
     },
     "repositories": [
         {
             "type": "git",
             "url": "https://github.com/markjaquith/wp-tlc-transients.git"
         }
-    ]
+    ],
+    "config": {
+        "vendor-dir": "wp-tlc-transients/"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,16 +2,12 @@
     "name": "webdevstudios/wds-tlc-transients",
     "type": "wordpress-plugin",
     "require": {
-        "markjaquith/wp-tlc-transients": "dev-master",
-        "composer/installers": "^1"
+        "markjaquith/wp-tlc-transients": "1.0"
     },
     "repositories": [
         {
             "type": "git",
             "url": "https://github.com/markjaquith/wp-tlc-transients.git"
         }
-    ],
-    "config": {
-        "vendor-dir": "wp-tlc-transients/"
-    }
+    ]
 }

--- a/wds-tlc-transients.php
+++ b/wds-tlc-transients.php
@@ -9,9 +9,31 @@
  * License: GPLv2 or later
  */
 
-// Get the bootstrap
-require_once 'wp-tlc-transients/tlc-transients.php';
+wds_tlc_load_dependency();
 
+/**
+ * Load this plugin's third-party dependency.
+ *
+ * Check whether it's relative to this plugin's root, or to the wp-content directory, using default Composer vendor
+ * directory names.
+ *
+ * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @since  2019-01-02
+ * @return void
+ */
+function wds_tlc_load_dependency() {
+	$file       = '/vendor/markjaquith/wp-tlc-transients/tlc-transients.php';
+	$paths = array_filter( [
+		untrailingslashit( __DIR__ ) . $file,
+		untrailingslashit( WP_CONTENT_DIR ) . $file,
+	], function ( $path ) {
+		return is_readable( $path );
+	} );
+
+	if ( count( $paths ) ) {
+		require_once $paths[0];
+	}
+}
 
 /**
  * Use in place of `get_posts()`.


### PR DESCRIPTION
Closes #1.

This change adds Mark Jaquith's library to the project as a dependency, then tries to load its PHP file either in the plugin's root or relative to the wp-content directory. 

Once this is merged, we will need to tag it as 1.0.1, update Satis, and any projects that require this via Composer.